### PR TITLE
ProvideBuffers API for buffer preregistration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot = "0.10.2"
 once_cell = "1.3.1"
 libc = "0.2.71"
 uring-sys = "0.6.1"
-iou = "0.0.0-ringbahn.1"
+iou = { path = "../iou" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/examples/read-event.rs
+++ b/examples/read-event.rs
@@ -9,7 +9,7 @@ fn main() -> io::Result<()> {
     let event = event::Read::new(&file, vec![0; meta.len() as usize], 0);
     let submission = Submission::new(event, driver);
     let content = futures::executor::block_on(async move {
-        let (event, result) = submission.await;
+        let (event, result, ..) = submission.await;
         let bytes_read = result?;
         let s = String::from_utf8_lossy(&event.buf[0..bytes_read]).to_string();
         io::Result::Ok(s)

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,80 +1,117 @@
 use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
 use std::io;
 use std::cmp;
-use std::mem;
-use std::ptr::NonNull;
+use std::pin::Pin;
+use std::mem::{self, MaybeUninit, ManuallyDrop};
+use std::task::{Poll, Context};
 use std::slice;
-use std::task::Poll;
 
 use futures_core::ready;
 use crate::Cancellation;
+use crate::drive::{Drive, ProvideBuffer};
+use crate::Ring;
 
-pub struct Buffer {
-    data: NonNull<()>,
-    storage: Storage,
-    capacity: u32,
+pub struct Buffer<D: Drive> {
+    storage: Storage<D>,
     pos: u32,
     cap: u32,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-enum Storage {
-    Nothing = 0,
-    Buffer,
-    Statx,
+enum Storage<D: Drive> {
+    Read(ManuallyDrop<D::ReadBuf>),
+    Write(ManuallyDrop<D::WriteBuf>),
+    Statx(ManuallyDrop<Box<MaybeUninit<libc::statx>>>),
+    Empty,
 }
 
-impl Buffer {
-    pub fn new() -> Buffer {
+impl<D: Drive> Buffer<D> {
+    pub fn new() -> Buffer<D> {
         Buffer {
-            data: NonNull::dangling(),
-            storage: Storage::Nothing,
-            capacity: 4096 * 2,
+            storage: Storage::Empty,
             pos: 0,
             cap: 0,
         }
     }
 
-    #[inline(always)]
     pub fn buffered_from_read(&self) -> &[u8] {
-        if self.storage == Storage::Buffer {
-            unsafe {
-                let data: *mut u8 = self.data.cast().as_ptr();
-                let cap = self.cap - self.pos;
-                slice::from_raw_parts(data.offset(self.pos as isize), cap as usize)
-            }
+        if let Storage::Read(buf) = &self.storage {
+            let ptr: *mut u8 = buf.as_ref().as_ptr() as *mut u8;
+            let cap = (self.cap - self.pos) as usize;
+            unsafe { slice::from_raw_parts(ptr.offset(self.pos as isize), cap) }
         } else {
             &[]
         }
     }
 
+    fn buffered_from_write(&self) -> &[u8] {
+        if let Storage::Write(buf) = &self.storage {
+            unsafe { mem::transmute(&buf.as_ref()[0..self.pos as usize]) }
+        } else {
+            &[]
+        }
+    }
+
+    // invariant: if fill returns N, it must actually ahve filled read buf up to n bytes
     #[inline]
-    pub fn fill_buf(&mut self, fill: impl FnOnce(&mut [u8]) -> Poll<io::Result<u32>>)
-        -> Poll<io::Result<&[u8]>>
-    {
-        match self.storage {
-            Storage::Buffer => {
+    pub unsafe fn fill_read_buf(
+        &mut self,
+        ctx: &mut Context<'_>,
+        mut ring: Pin<&mut Ring<D>>,
+        fill: impl FnOnce(Pin<&mut Ring<D>>, &mut Context<'_>, &mut D::ReadBuf) -> Poll<io::Result<u32>>
+    ) -> Poll<io::Result<&[u8]>> {
+        match &mut self.storage {
+            Storage::Read(buf)  => {
                 if self.pos >= self.cap {
-                    let buf = unsafe {
-                        slice::from_raw_parts_mut(self.data.cast().as_ptr(), self.capacity as usize)
-                    };
-                    self.cap = ready!(fill(buf))?;
+                    self.cap = ready!(fill(ring, ctx, &mut *buf))?;
                     self.pos = 0;
                 }
+                Poll::Ready(Ok(self.buffered_from_read()))
+            }
+            Storage::Empty      => {
+                ready!(self.alloc_read_buf(ctx, ring.as_mut()))?;
+                if let Storage::Read(buf) = &mut self.storage {
+                    if self.pos >= self.cap {
+                        self.pos = ready!(fill(ring, ctx, &mut *buf))?;
+                        self.cap = 0;
+                    }
+                    Poll::Ready(Ok(self.buffered_from_read()))
+                } else { unreachable!() }
+            }
+            _                   => panic!("attempted to fill read buf while holding other buf"),
+        }
+    }
 
-                Poll::Ready(Ok(self.buffered_from_read()))
+    #[inline]
+    pub fn fill_write_buf(
+        &mut self,
+        ctx: &mut Context<'_>,
+        mut ring: Pin<&mut Ring<D>>,
+        fill: impl FnOnce(Pin<&mut Ring<D>>, &mut Context<'_>, &mut D::WriteBuf) -> Poll<io::Result<u32>>
+    ) -> Poll<io::Result<&[u8]>> {
+        match &mut self.storage {
+            Storage::Write(buf)  => {
+                if self.pos == 0 {
+                    self.pos = ready!(fill(ring, ctx, &mut *buf))?;
+                }
+                Poll::Ready(Ok(self.buffered_from_write()))
             }
-            Storage::Nothing => {
-                self.cap = ready!(fill(self.alloc_buf()))?;
-                Poll::Ready(Ok(self.buffered_from_read()))
+            Storage::Empty      => {
+                ready!(self.alloc_write_buf(ctx, ring.as_mut()))?;
+                if let Storage::Write(buf) = &mut self.storage {
+                    if self.pos == 0 {
+                        self.pos = ready!(fill(ring, ctx, &mut *buf))?;
+                    }
+                    Poll::Ready(Ok(self.buffered_from_write()))
+                } else { unreachable!() }
             }
-            _               => panic!("attempted to fill buf while not holding buffer"),
+            _                   => panic!("attempted to fill read buf while holding other buf"),
         }
     }
 
     #[inline(always)]
-    pub fn consume(&mut self, amt: usize) {
-        self.pos = cmp::min(self.pos + amt as u32, self.cap);
+    pub fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = unsafe { Pin::get_unchecked_mut(self) };
+        this.pos = cmp::min(this.pos + amt as u32, this.cap);
     }
 
     #[inline(always)]
@@ -84,82 +121,77 @@ impl Buffer {
     }
 
     pub fn cancellation(&mut self) -> Cancellation {
-        match self.storage {
-            Storage::Buffer     => {
-                self.clear();
-                self.storage = Storage::Nothing;
-                let data = mem::replace(&mut self.data, NonNull::dangling());
-                unsafe { Cancellation::buffer(data.cast().as_ptr(), self.capacity as usize) }
-            }
-            Storage::Statx      => {
+        let cancellation = match &mut self.storage {
+            Storage::Read(buf)      => unsafe { ProvideBuffer::cleanup(buf) },
+            Storage::Write(buf)     => unsafe { ProvideBuffer::cleanup(buf) },
+            Storage::Statx(statx)   => {
                 unsafe fn callback(statx: *mut (), _: usize) {
                     dealloc(statx as *mut u8, Layout::new::<libc::statx>())
                 }
 
-                self.storage = Storage::Nothing;
-                let data = mem::replace(&mut self.data, NonNull::dangling());
                 unsafe {
-                    Cancellation::new(data.cast().as_ptr(), 0, callback)
+                    let statx = Box::into_raw(ManuallyDrop::take(statx));
+                    Cancellation::new(statx as *mut (), 0, callback)
                 }
             }
-            Storage::Nothing    => Cancellation::null(),
-        }
+            Storage::Empty        => Cancellation::null(),
+        };
+        self.storage = Storage::Empty;
+        cancellation
     }
 
     pub(crate) fn as_statx(&mut self) -> *mut libc::statx {
-        match self.storage {
-            Storage::Statx      => self.data.cast().as_ptr(),
-            Storage::Nothing    => self.alloc_statx(),
-            _                   => panic!("accessed buffer as statx when storing something else"),
-        }
-    }
-
-    fn alloc_buf(&mut self) -> &mut [u8] {
-        self.storage = Storage::Buffer;
-        self.alloc();
-        unsafe {
-            slice::from_raw_parts_mut(self.data.cast().as_ptr(), self.capacity as usize)
-        }
-    }
-
-    fn alloc_statx(&mut self) -> &mut libc::statx {
-        self.storage = Storage::Statx;
-        self.alloc();
-        unsafe {
-            &mut *self.data.cast().as_ptr()
-        }
-    }
-
-    fn alloc(&mut self) {
-        unsafe {
-            let layout = self.layout().unwrap();
-            let ptr = alloc(layout);
-            if ptr.is_null() {
-                self.storage = Storage::Nothing;
-                handle_alloc_error(layout)
+        match &mut self.storage {
+            Storage::Statx(statx)   => statx.as_mut_ptr(),
+            Storage::Empty          => {
+                self.alloc_statx();
+                if let Storage::Statx(statx) = &mut self.storage {
+                    statx.as_mut_ptr()
+                } else { unreachable!() }
             }
-            self.data = NonNull::new_unchecked(ptr).cast();
+            _                       => panic!("accessed buffer as statx when storing something else"),
         }
     }
 
-    #[inline(always)]
-    fn layout(&self) -> Option<Layout> {
-        match self.storage {
-            Storage::Statx      => Some(Layout::new::<libc::statx>()),
-            Storage::Buffer     => Some(Layout::array::<u8>(self.capacity as usize).unwrap()),
-            Storage::Nothing    => None,
+    fn alloc_read_buf(&mut self, ctx: &mut Context<'_>, ring: Pin<&mut Ring<D>>)
+        -> Poll<io::Result<()>>
+    {
+        let buf = ready!(ring.driver_pinned().poll_provide_read_buf(ctx, 4096 * 2))?;
+        self.storage = Storage::Read(ManuallyDrop::new(buf));
+        Poll::Ready(Ok(()))
+    }
+
+    fn alloc_write_buf(&mut self, ctx: &mut Context<'_>, ring: Pin<&mut Ring<D>>)
+        -> Poll<io::Result<()>>
+    {
+        let buf = ready!(ring.driver_pinned().poll_provide_write_buf(ctx, 4096 * 2))?;
+        self.storage = Storage::Write(ManuallyDrop::new(buf));
+        Poll::Ready(Ok(()))
+    }
+
+    fn alloc_statx(&mut self) {
+        unsafe {
+            let layout = Layout::new::<libc::statx>();
+            let statx = alloc(layout);
+            if statx.is_null() {
+                handle_alloc_error(layout);
+            }
+            self.storage = Storage::Statx(ManuallyDrop::new(Box::from_raw(statx as *mut _)));
         }
     }
 }
 
-unsafe impl Send for Buffer { }
-unsafe impl Sync for Buffer { }
+unsafe impl<D: Drive> Send for Buffer<D> where D::ReadBuf: Send, D::WriteBuf: Send { }
+unsafe impl<D: Drive> Sync for Buffer<D> where D::ReadBuf: Sync, D::WriteBuf: Sync { }
 
-impl Drop for Buffer {
+impl<D: Drive> Drop for Buffer<D> {
     fn drop(&mut self) {
-        if let Some(layout) = self.layout() {
-            unsafe {
-                dealloc(self.data.cast().as_ptr(), layout);
+        unsafe {
+            match &mut self.storage {
+                Storage::Read(buf)      => ManuallyDrop::drop(buf),
+                Storage::Write(buf)     => ManuallyDrop::drop(buf),
+                Storage::Statx(statx)   => ManuallyDrop::drop(statx),
+                Storage::Empty          => return,
             }
         }
     }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -104,8 +104,12 @@ impl<D: Drive> Buffer<D> {
 
     pub fn cancellation(&mut self) -> Cancellation {
         let cancellation = match &mut self.storage {
-            Storage::Read(buf)      => unsafe { ProvideBuffer::cleanup(buf) },
-            Storage::Write(buf)     => unsafe { ProvideBuffer::cleanup(buf) },
+            Storage::Read(buf)      => unsafe {
+                ProvideBuffer::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)))
+            }
+            Storage::Write(buf)     => unsafe {
+                ProvideBuffer::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)))
+            }
             Storage::Statx(statx)   => {
                 unsafe fn callback(statx: *mut (), _: usize) {
                     dealloc(statx as *mut u8, Layout::new::<libc::statx>())

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -9,7 +9,7 @@ use std::slice;
 
 use futures_core::ready;
 use crate::Cancellation;
-use crate::drive::{Drive, ProvideBuffer};
+use crate::drive::{Drive, ProvideBufferSealed};
 use crate::Ring;
 
 pub struct Buffer<D: Drive> {
@@ -114,10 +114,10 @@ impl<D: Drive> Buffer<D> {
     pub fn cancellation(&mut self, driver: Pin<&mut D>) -> Cancellation {
         let cancellation = match &mut self.storage {
             Storage::Read(buf)      => unsafe {
-                ProvideBuffer::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)), driver)
+                ProvideBufferSealed::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)), driver)
             }
             Storage::Write(buf)     => unsafe {
-                ProvideBuffer::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)), driver)
+                ProvideBufferSealed::cleanup(ManuallyDrop::new(ManuallyDrop::take(buf)), driver)
             }
             Storage::Statx(statx)   => {
                 unsafe fn callback(statx: *mut (), _: usize, _: u32) {

--- a/src/drive/buf.rs
+++ b/src/drive/buf.rs
@@ -1,4 +1,5 @@
 use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use std::cmp;
 use std::io;
 use std::mem::{MaybeUninit, ManuallyDrop};
 use std::pin::Pin;
@@ -9,32 +10,23 @@ use std::slice;
 use crate::Cancellation;
 use super::Drive;
 
-pub trait ProvideBuffer<D: Drive>: AsRef<[MaybeUninit<u8>]> + AsMut<[MaybeUninit<u8>]> + Sized {
+pub trait ProvideBuffer<D: Drive>: Sized {
     fn poll_provide(driver: Pin<&mut D>, ctx: &mut Context<'_>, capacity: usize)
         -> Poll<io::Result<Self>>;
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>);
+
+    unsafe fn fill(&mut self, data: &[u8]);
+    unsafe fn as_slice(&self) -> &[MaybeUninit<u8>];
+
+    unsafe fn prepare_read(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>);
+    unsafe fn prepare_write(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>);
+
     unsafe fn cleanup(this: &mut ManuallyDrop<Self>) -> Cancellation;
 }
 
 pub struct HeapBuffer {
     data: NonNull<MaybeUninit<u8>>,
+    filled: u32,
     capacity: u32,
-}
-
-impl AsRef<[MaybeUninit<u8>]> for HeapBuffer {
-    fn as_ref(&self) -> &[MaybeUninit<u8>] {
-        unsafe {
-            slice::from_raw_parts(self.data.as_ptr(), self.capacity as usize)
-        }
-    }
-}
-
-impl AsMut<[MaybeUninit<u8>]> for HeapBuffer {
-    fn as_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        unsafe {
-            slice::from_raw_parts_mut(self.data.as_ptr(), self.capacity as usize)
-        }
-    }
 }
 
 impl<D: Drive> ProvideBuffer<D> for HeapBuffer {
@@ -50,14 +42,37 @@ impl<D: Drive> ProvideBuffer<D> for HeapBuffer {
             }
             Poll::Ready(Ok(HeapBuffer {
                 data: NonNull::new_unchecked(ptr).cast(),
-                capacity: capacity as u32
+                capacity: capacity as u32,
+                filled: 0,
             }))
         }
     }
-    
-    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
-        sqe.raw_mut().addr = self.data.as_ptr() as usize as u64;
-        sqe.raw_mut().len = self.capacity;
+
+    unsafe fn fill(&mut self, data: &[u8]) {
+        let n = cmp::min(data.len(), self.capacity as usize);
+        let slice = slice::from_raw_parts_mut(self.data.cast().as_ptr(), n);
+        slice.copy_from_slice(&data[..n]);
+        self.filled = n as u32;
+    }
+
+    unsafe fn as_slice(&self) -> &[MaybeUninit<u8>] {
+        slice::from_raw_parts(self.data.as_ptr(), self.capacity as usize)
+    }
+
+    unsafe fn prepare_read(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+        let sqe = sqe.raw_mut();
+        sqe.addr = self.data.as_ptr() as usize as u64;
+        sqe.len = self.capacity;
+        sqe.opcode = uring_sys::IoRingOp::IORING_OP_READ as u8;
+        sqe.cmd_flags.rw_flags = 0;
+    }
+
+    unsafe fn prepare_write(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+        let sqe = sqe.raw_mut();
+        sqe.addr = self.data.as_ptr() as usize as u64;
+        sqe.len = self.filled;
+        sqe.opcode = uring_sys::IoRingOp::IORING_OP_WRITE as u8;
+        sqe.cmd_flags.rw_flags = 0;
     }
 
     unsafe fn cleanup(this: &mut ManuallyDrop<Self>) -> Cancellation {

--- a/src/drive/buf.rs
+++ b/src/drive/buf.rs
@@ -1,0 +1,78 @@
+use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use std::io;
+use std::mem::{MaybeUninit, ManuallyDrop};
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::task::{Poll, Context};
+use std::slice;
+
+use crate::Cancellation;
+use super::Drive;
+
+pub trait ProvideBuffer<D: Drive>: AsRef<[MaybeUninit<u8>]> + AsMut<[MaybeUninit<u8>]> + Sized {
+    fn poll_provide(driver: Pin<&mut D>, ctx: &mut Context<'_>, capacity: usize)
+        -> Poll<io::Result<Self>>;
+    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>);
+    unsafe fn cleanup(this: &mut ManuallyDrop<Self>) -> Cancellation;
+}
+
+pub struct HeapBuffer {
+    data: NonNull<MaybeUninit<u8>>,
+    capacity: u32,
+}
+
+impl AsRef<[MaybeUninit<u8>]> for HeapBuffer {
+    fn as_ref(&self) -> &[MaybeUninit<u8>] {
+        unsafe {
+            slice::from_raw_parts(self.data.as_ptr(), self.capacity as usize)
+        }
+    }
+}
+
+impl AsMut<[MaybeUninit<u8>]> for HeapBuffer {
+    fn as_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        unsafe {
+            slice::from_raw_parts_mut(self.data.as_ptr(), self.capacity as usize)
+        }
+    }
+}
+
+impl<D: Drive> ProvideBuffer<D> for HeapBuffer {
+    fn poll_provide(_: Pin<&mut D>, _: &mut Context<'_>, capacity: usize)
+        -> Poll<io::Result<Self>>
+    {
+        assert!(capacity <= u32::MAX as usize);
+        unsafe {
+            let layout = Layout::array::<MaybeUninit<u8>>(capacity).unwrap();
+            let ptr = alloc(layout);
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+            Poll::Ready(Ok(HeapBuffer {
+                data: NonNull::new_unchecked(ptr).cast(),
+                capacity: capacity as u32
+            }))
+        }
+    }
+    
+    unsafe fn prepare(&mut self, sqe: &mut iou::SubmissionQueueEvent<'_>) {
+        sqe.raw_mut().addr = self.data.as_ptr() as usize as u64;
+        sqe.raw_mut().len = self.capacity;
+    }
+
+    unsafe fn cleanup(this: &mut ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::buffer(this.data.cast().as_ptr(), this.capacity as usize)
+    }
+}
+
+unsafe impl Send for HeapBuffer { }
+unsafe impl Sync for HeapBuffer { }
+
+impl Drop for HeapBuffer {
+    fn drop(&mut self) {
+        let layout = Layout::array::<MaybeUninit<u8>>(self.capacity as usize).unwrap();
+        unsafe {
+            dealloc(self.data.cast().as_ptr(), layout);
+        }
+    }
+}

--- a/src/drive/buf.rs
+++ b/src/drive/buf.rs
@@ -34,7 +34,7 @@ impl<D: Drive + ?Sized> ProvideBuffer<D> for HeapBuffer {
     fn poll_provide(_: Pin<&mut D>, _: &mut Context<'_>, capacity: usize)
         -> Poll<io::Result<Self>>
     {
-        assert!(capacity <= u32::MAX as usize);
+        let capacity = cmp::min(capacity, u32::MAX as usize);
         unsafe {
             let layout = Layout::array::<MaybeUninit<u8>>(capacity).unwrap();
             let ptr = alloc(layout);

--- a/src/drive/buf.rs
+++ b/src/drive/buf.rs
@@ -10,9 +10,10 @@ use std::slice;
 use crate::Cancellation;
 use super::Drive;
 
-pub trait ProvideBuffer<D: Drive>: Sized {
+pub trait ProvideBuffer<D: Drive + ?Sized> {
     fn poll_provide(driver: Pin<&mut D>, ctx: &mut Context<'_>, capacity: usize)
-        -> Poll<io::Result<Self>>;
+        -> Poll<io::Result<Self>>
+    where Self: Sized;
 
     unsafe fn fill(&mut self, data: &[u8]);
     unsafe fn as_slice(&self) -> &[MaybeUninit<u8>];
@@ -29,7 +30,7 @@ pub struct HeapBuffer {
     capacity: u32,
 }
 
-impl<D: Drive> ProvideBuffer<D> for HeapBuffer {
+impl<D: Drive + ?Sized> ProvideBuffer<D> for HeapBuffer {
     fn poll_provide(_: Pin<&mut D>, _: &mut Context<'_>, capacity: usize)
         -> Poll<io::Result<Self>>
     {

--- a/src/drive/demo.rs
+++ b/src/drive/demo.rs
@@ -15,7 +15,7 @@ const CQ_ENTRIES: usize = (SQ_ENTRIES * 2) as usize;
 
 use access_queue::*;
 
-use super::{Drive, Completion};
+use super::{Drive, HeapBuffer, Completion};
 
 static SQ: Lazy<AccessQueue<Mutex<iou::SubmissionQueue<'static>>>> = Lazy::new(init_sq);
 
@@ -37,6 +37,9 @@ impl<'a> Clone for DemoDriver<'a> {
 }
 
 impl Drive for DemoDriver<'_> {
+    type ReadBuf = HeapBuffer;
+    type WriteBuf = HeapBuffer;
+
     fn poll_prepare<'cx>(
         mut self: Pin<&mut Self>,
         ctx: &mut Context<'cx>,

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -11,7 +11,7 @@ use std::task::{Context, Poll};
 use crate::completion;
 
 pub use crate::completion::complete;
-pub use buf::{ProvideBuffer, HeapBuffer};
+pub use buf::*;
 
 /// A ccompletion which will be used to wake the task waiting on this event.
 ///

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -5,13 +5,17 @@ mod buf;
 
 use std::io;
 use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::completion;
+use crate::Cancellation;
 
 pub use crate::completion::complete;
-pub use buf::*;
+pub use buf::{ProvideReadBuf, ProvideWriteBuf, HeapBuffer, RegisteredBuffer, GroupRegisteredBuffer};
+pub use buf::BufferId;
+pub(crate) use buf::ProvideBufferSealed;
 
 /// A ccompletion which will be used to wake the task waiting on this event.
 ///
@@ -34,8 +38,8 @@ impl<'cx> Completion<'cx> {
 /// instance. Paired with a piece of code which processes completions, it can run IO on top of
 /// io-uring.
 pub trait Drive {
-    type ReadBuf: ProvideBuffer<Self>;
-    type WriteBuf: ProvideBuffer<Self>;
+    type ReadBuf: ProvideReadBuf<Self>;
+    type WriteBuf: ProvideWriteBuf<Self>;
 
     /// Prepare an event on the submission queue.
     ///
@@ -79,7 +83,7 @@ pub trait Drive {
     fn poll_provide_read_buf(
         self: Pin<&mut Self>,
         ctx: &mut Context<'_>,
-        capacity: usize,
+        capacity: u32,
     ) -> Poll<io::Result<Self::ReadBuf>> {
         Self::ReadBuf::poll_provide(self, ctx, capacity)
     }
@@ -87,8 +91,80 @@ pub trait Drive {
     fn poll_provide_write_buf(
         self: Pin<&mut Self>,
         ctx: &mut Context<'_>,
-        capacity: usize,
+        capacity: u32,
     ) -> Poll<io::Result<Self::WriteBuf>> {
         Self::WriteBuf::poll_provide(self, ctx, capacity)
     }
+}
+
+/// A driver which can use pre-registered buffers.
+///
+/// Buffers provided through this API should be pre-registered with the `io_uring_register`
+/// syscall.
+pub trait RegisterBuffer: Drive {
+    /// Provide a pre-registered buffer.
+    ///
+    /// This buffer should have been pre-registered with the io-uring instance the drive is a
+    /// handle for. The `upper_idx` field of the BufferId struct should be the index of the
+    /// preregistered buffer this is a part of. You may use the `lower_idx` field for additional
+    /// tracking (for example, if this buffer only represents part of the pre-registered buffer).
+    ///
+    /// If the buffer returned is *not* part of a pre-registered buffer tracked by the buffer id,
+    /// attempts to use this buffer to perform IO will result in errors.
+    ///
+    /// The capacity argument is just a suggestion: the implementer is allowed to return a heap
+    /// buffer with a different capacity from the one requested.
+    fn poll_provide_registered(self: Pin<&mut Self>, ctx: &mut Context<'_>, capacity: u32)
+        -> Poll<io::Result<(HeapBuffer, BufferId)>>;
+
+    /// Clean up a registered buffer.
+    ///
+    /// This method will be called when a buffer is no longer in use, though it may be currently
+    /// owned by the kernel for some IO event. The constructed cancellation will clean up this
+    /// resource as soon as the kernel no longer needs access to the buffer.
+    ///
+    /// This could deallocate the buffer or it could return the buffer to a pool. The `idx`
+    /// argument will be exactly the `idx` passed with this buffer in `poll_provide_registered`,
+    /// including the same value in `lower_idx`, which you may use to track custom information
+    /// about this buffer.
+    fn cleanup_registered(self: Pin<&mut Self>, buf: ManuallyDrop<HeapBuffer>, idx: BufferId) -> Cancellation;
+}
+
+/// A driver which can provide buffers from pre-registered buffer groups.
+///
+/// Buffers provided through this API should be registered with io-uring using the
+/// `IORING_OP_PROVIDE_BUFFERS` operation.
+pub trait RegisterBufferGroup: Drive {
+    /// Provide a group id from which to pull a pre-registered buffer. This will be passed with a
+    /// read event, which perform the read into one of the buffers in that group.
+    ///
+    /// The capacity argument is just a suggestion: the implementer is allowed to return a buffer
+    /// group which contains buffers with a different capacity from the one suggested.
+    fn poll_provide_group(self: Pin<&mut Self>, ctx: &mut Context<'_>, capacity: u32)
+        -> Poll<io::Result<u16>>;
+
+    /// Prepare a cancellation for a request that has used a buffer group.
+    ///
+    /// When this cancellation's callback is called, the third argument will either be 0, or it
+    /// will contain the buffer index the IO was performed into. The buffer with that index in the
+    /// group indicated will be have been removed from the kernel's set of available buffers. You
+    /// can implement the callback to clean up that buffer in whatever way would be appropriate,
+    /// such as deallocating it or returning it to the pool.
+    fn cancel_requested_buffer(self: Pin<&mut Self>, group: u16) -> Cancellation;
+
+    /// Access a buffer from the buffer group.
+    ///
+    /// The BufferId's `upper_idx` field will be the group index, the `lower_idx` field will be the
+    /// buffer index within that group.
+    ///
+    /// # Safety
+    ///
+    /// This method guarantees that it is called using a group and buffer index returned from a
+    /// completed IO event, so it is guaranteed the kernel is not currently accessing it. It is
+    /// safe for the caller to return the buffer even though it has previously been shared with the
+    /// kernel.
+    unsafe fn access_buffer(self: Pin<&mut Self>, idx: BufferId) -> HeapBuffer;
+
+    /// Clean up a buffer that has been taken from a group.
+    fn cleanup_group_buffer(self: Pin<&mut Self>, buf: ManuallyDrop<HeapBuffer>, idx: BufferId);
 }

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -33,7 +33,7 @@ impl<'cx> Completion<'cx> {
 /// The type that implements `Drive` is used to prepare and submit IO events to an io-uring
 /// instance. Paired with a piece of code which processes completions, it can run IO on top of
 /// io-uring.
-pub trait Drive: Sized {
+pub trait Drive {
     type ReadBuf: ProvideBuffer<Self>;
     type WriteBuf: ProvideBuffer<Self>;
 

--- a/src/event/connect.rs
+++ b/src/event/connect.rs
@@ -25,7 +25,7 @@ impl Event for Connect {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(addr: *mut (), _: usize) {
+        unsafe fn callback(addr: *mut (), _: usize, _: u32) {
             dealloc(addr as *mut u8, Layout::new::<libc::sockaddr_storage>());
         }
         Cancellation::new(&mut *this.addr as *mut libc::sockaddr_storage as *mut (), 0, callback)

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,10 +1,9 @@
 //! Interact with the file system using io-uring
 
-use std::cmp;
 use std::fs;
 use std::future::Future;
 use std::io;
-use std::mem::{self, MaybeUninit, ManuallyDrop};
+use std::mem::ManuallyDrop;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::path::Path;
 use std::pin::Pin;
@@ -168,15 +167,9 @@ impl<D: Drive> AsyncBufRead for File<D> {
         unsafe {
             buf.fill_read_buf(ctx, ring, |ring, ctx, buf| {
                 let n = ready!(ring.poll(ctx, true, |sqe| {
-                    buf.prepare(sqe);
-                    let sqe = sqe.raw_mut();
-                    sqe.opcode = uring_sys::IoRingOp::IORING_OP_READ as u8;
-                    sqe.flags = 0;
-                    sqe.ioprio = 0;
-                    sqe.fd = fd;
-                    sqe.off_addr2.off = *pos as u64;
-                    sqe.cmd_flags.rw_flags = 0;
-                    sqe.user_data = 0;
+                    buf.prepare_read(sqe);
+                    sqe.raw_mut().fd = fd;
+                    sqe.raw_mut().off_addr2.off = *pos as u64;
                 }))?;
                 *pos += n;
                 Poll::Ready(Ok(n as u32))
@@ -194,15 +187,12 @@ impl<D: Drive> AsyncWrite for File<D> {
         self.as_mut().guard_op(Op::Write);
         let fd = self.fd;
         let (mut ring, buf, pos) = self.split();
-        let data = unsafe { ready!(buf.fill_write_buf(ctx, ring.as_mut(), |_, _, buf| {
-            let buf: &mut [MaybeUninit<u8>] = buf.as_mut();
-            let n = cmp::min(slice.len(), buf.len());
-            let buf = &mut buf[..n];
-            let slice = &slice[..n];
-            mem::transmute::<_, &mut [u8]>(buf).copy_from_slice(slice);
-            Poll::Ready(Ok(n as u32))
-        }))? };
-        let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_write(fd, data, *pos) }))?;
+        let data = ready!(buf.fill_write_buf(ctx, ring.as_mut(), slice))?;
+        let n = ready!(ring.poll(ctx, true, |sqe| unsafe {
+            data.prepare_write(sqe);
+            sqe.raw_mut().fd = fd;
+            sqe.raw_mut().off_addr2.off = *pos as u64;
+        }))?;
         *pos += n;
         buf.clear();
         Poll::Ready(Ok(n))

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -14,7 +14,7 @@ use futures_core::ready;
 use futures_io::{AsyncRead, AsyncBufRead, AsyncWrite, AsyncSeek};
 
 use crate::buf::Buffer;
-use crate::drive::{Drive, ProvideBuffer};
+use crate::drive::{Drive, ProvideBufferSealed};
 use crate::drive::demo::DemoDriver;
 use crate::ring::Ring;
 use crate::event::OpenAt;

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -9,7 +9,7 @@ use futures_core::ready;
 use futures_io::{AsyncRead, AsyncBufRead, AsyncWrite};
 
 use crate::buf::Buffer;
-use crate::drive::{Drive, ProvideBuffer};
+use crate::drive::{Drive, ProvideBufferSealed};
 use crate::drive::demo::DemoDriver;
 use crate::{Ring, Submission};
 use crate::event;

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -1,5 +1,7 @@
+use std::cmp;
 use std::io;
 use std::future::Future;
+use std::mem::{self, MaybeUninit};
 use std::net::ToSocketAddrs;
 use std::os::unix::io::RawFd;
 use std::pin::Pin;
@@ -9,16 +11,16 @@ use futures_core::ready;
 use futures_io::{AsyncRead, AsyncBufRead, AsyncWrite};
 
 use crate::buf::Buffer;
+use crate::drive::{Drive, ProvideBuffer};
 use crate::drive::demo::DemoDriver;
-use crate::{Drive, Ring};
+use crate::{Ring, Submission};
 use crate::event;
-use crate::Submission;
 
 use super::socket;
 
 pub struct TcpStream<D: Drive = DemoDriver<'static>> {
     ring: Ring<D>,
-    buf: Buffer,
+    buf: Buffer<D>,
     active: Op,
     fd: RawFd,
 }
@@ -75,12 +77,12 @@ impl<D: Drive> TcpStream<D> {
     }
 
     #[inline(always)]
-    fn buf(self: Pin<&mut Self>) -> Pin<&mut Buffer> {
+    fn buf(self: Pin<&mut Self>) -> Pin<&mut Buffer<D>> {
         unsafe { Pin::map_unchecked_mut(self, |this| &mut this.buf) }
     }
 
     #[inline(always)]
-    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer) {
+    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer<D>) {
         unsafe {
             let this = Pin::get_unchecked_mut(self);
             (Pin::new_unchecked(&mut this.ring), &mut this.buf)
@@ -130,10 +132,22 @@ impl<D: Drive> AsyncBufRead for TcpStream<D> {
         self.as_mut().guard_op(Op::Read);
         let fd = self.fd;
         let (ring, buf) = self.split();
-        buf.fill_buf(|buf| {
-            let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_read(fd, buf, 0) }))?;
-            Poll::Ready(Ok(n as u32))
-        })
+        unsafe {
+            buf.fill_read_buf(ctx, ring, |ring, ctx, buf| {
+                let n = ready!(ring.poll(ctx, true, |sqe| {
+                    buf.prepare(sqe);
+                    let sqe = sqe.raw_mut();
+                    sqe.opcode = uring_sys::IoRingOp::IORING_OP_READ as u8;
+                    sqe.flags = 0;
+                    sqe.ioprio = 0;
+                    sqe.fd = fd;
+                    sqe.off_addr2.off = 0;
+                    sqe.cmd_flags.rw_flags = 0;
+                    sqe.user_data = 0;
+                }))?;
+                Poll::Ready(Ok(n as u32))
+            })
+        }
     }
 
     fn consume(self: Pin<&mut Self>, amt: usize) {
@@ -145,10 +159,15 @@ impl<D: Drive> AsyncWrite for TcpStream<D> {
     fn poll_write(mut self: Pin<&mut Self>, ctx: &mut Context<'_>, slice: &[u8]) -> Poll<io::Result<usize>> {
         self.as_mut().guard_op(Op::Write);
         let fd = self.fd;
-        let (ring, buf) = self.split();
-        let data = ready!(buf.fill_buf(|mut buf| {
-            Poll::Ready(Ok(io::Write::write(&mut buf, slice)? as u32))
-        }))?;
+        let (mut ring, buf) = self.split();
+        let data = unsafe { ready!(buf.fill_write_buf(ctx, ring.as_mut(), |_, _, buf| {
+            let buf: &mut [MaybeUninit<u8>] = buf.as_mut();
+            let n = cmp::min(slice.len(), buf.len());
+            let buf = &mut buf[..n];
+            let slice = &slice[..n];
+            mem::transmute::<_, &mut [u8]>(buf).copy_from_slice(slice);
+            Poll::Ready(Ok(n as u32))
+        }))? };
         let n = ready!(ring.poll(ctx, true, |sqe| unsafe { sqe.prep_write(fd, data, 0) }))?;
         buf.clear();
         Poll::Ready(Ok(n))

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -82,7 +82,7 @@ impl<D: Drive> Ring<D> {
         ctx: &mut Context<'_>,
         is_eager: bool,
         prepare: impl FnOnce(&mut iou::SubmissionQueueEvent<'_>),
-    ) -> Poll<io::Result<usize>> {
+    ) -> Poll<(io::Result<usize>, u32)> {
         match self.state {
             Inert       => {
                 ready!(self.as_mut().poll_prepare(ctx, prepare));
@@ -145,7 +145,7 @@ impl<D: Drive> Ring<D> {
     }
 
     #[inline(always)]
-    fn poll_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+    fn poll_complete(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<(io::Result<usize>, u32)> {
         let (_, state, completion_slot) = self.split();
         match completion_slot.take().unwrap().check(ctx.waker()) {
             Ok(result)      => {

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -66,6 +66,10 @@ impl<D: Drive> Ring<D> {
         &self.driver
     }
 
+    pub fn driver_pinned(self: Pin<&mut Self>) -> Pin<&mut D> {
+        unsafe { Pin::map_unchecked_mut(self, |this| &mut this.driver) }
+    }
+
     /// Poll the ring state machine.
     ///
     /// This accepts a callback, `prepare`, which prepares an event to be submitted to io-uring.

--- a/tests/basic-read.rs
+++ b/tests/basic-read.rs
@@ -10,7 +10,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn read_file() {
     let file = File::open("props.txt").unwrap();
     let read: Read<'_, File> = Read::new(&file, vec![0; 4096], 0);
-    let (read, result) = futures::executor::block_on(Submission::new(read, demo::driver()));
+    let (read, result, ..) = futures::executor::block_on(Submission::new(read, demo::driver()));
     assert!(result.is_ok());
     assert_eq!(&read.buf[0..ASSERT.len()], ASSERT);
 }

--- a/tests/basic-write.rs
+++ b/tests/basic-write.rs
@@ -11,7 +11,7 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 fn write_file() {
     let mut file = tempfile::tempfile().unwrap();
     let write: Write<'_, File> = Write::new(&file, Vec::from(ASSERT), 0);
-    let (_, result) = futures::executor::block_on(Submission::new(write, demo::driver()));
+    let (_, result, _) = futures::executor::block_on(Submission::new(write, demo::driver()));
     assert_eq!(result.unwrap(), ASSERT.len());
 
     let mut buf = vec![];


### PR DESCRIPTION
The Drive API is extended with two associated types - the read buffer and the write buffer types - which both must implement a trait called `ProvideBuffer`. This trait abstracts the notion of providing a buffer for IO to be preformed in.

Three buffer types are provided:

* `HeapBuffer`, which is a simple heap allocated buffer
* `RegisteredBuffer`, which a buffer that has been preregistered with io_uring_register
* `GroupRegisteredBuffer`, (only valid as a read buffer), which uses the automatic buffer selection group registration API

Both of the latter two APIs require the underlying drive handle to implement additional extension to support their operation.

Closes #2