### PR TITLE
Improve code around closing.

### DIFF
--- a/tests/file-close.rs
+++ b/tests/file-close.rs
@@ -1,0 +1,16 @@
+use futures::{AsyncReadExt, AsyncWriteExt};
+
+use ringbahn::File;
+
+const ASSERT: &[u8] = b"But this formidable power of death -";
+
+#[test]
+fn read_and_close_file() {
+    futures::executor::block_on(async move {
+        let mut file = File::open("props.txt").await.unwrap();
+        let mut buf = vec![0; 4096];
+        assert!(file.read(&mut buf).await.is_ok());
+        assert_eq!(&buf[0..ASSERT.len()], ASSERT);
+        file.close().await.unwrap();
+    });
+}


### PR DESCRIPTION
All IO objects will be closed in a blocking fashion if they have not
been closed asynchronously (closes #46). Also, they will panic if
the user attempts to perform IO after they have been closed.

UnixStream is made a thin wrapper around TcpStream instead of
duplicating a lot of code.