### PR TITLE
Safer API for Cancellation.

### DIFF
--- a/src/event/connect.rs
+++ b/src/event/connect.rs
@@ -20,9 +20,6 @@ impl Event for Connect {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(addr: *mut (), _: usize) {
-            drop(Box::from_raw(addr as *mut SockAddr));
-        }
-        Cancellation::new(&mut *this.addr as *mut SockAddr as *mut (), 0, callback)
+        Cancellation::object(ManuallyDrop::take(this).addr)
     }
 }

--- a/src/event/files_update.rs
+++ b/src/event/files_update.rs
@@ -1,6 +1,5 @@
 use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
-use std::slice;
 
 use super::{Event, SQE, SQEs, Cancellation};
 
@@ -19,11 +18,6 @@ impl Event for FilesUpdate {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(data: *mut (), len: usize) {
-            drop(Box::from_raw(slice::from_raw_parts_mut(data as *mut RawFd, len)))
-        }
-        let mut files: ManuallyDrop<Box<[RawFd]>> = ManuallyDrop::new(ManuallyDrop::take(this).files);
-        let cap = files.len();
-        Cancellation::new(files.as_mut_ptr() as *mut (), cap, callback)
+        Cancellation::buffer(ManuallyDrop::take(this).files)
     }
 }

--- a/src/event/openat.rs
+++ b/src/event/openat.rs
@@ -32,9 +32,6 @@ impl Event for OpenAt {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(addr: *mut (), _: usize) {
-            drop(CString::from_raw(addr as *mut _));
-        }
-        Cancellation::new(this.path.as_ptr() as *const () as *mut (), 0, callback)
+        Cancellation::cstring(ManuallyDrop::take(this).path)
     }
 }

--- a/src/event/provide_buffers.rs
+++ b/src/event/provide_buffers.rs
@@ -21,9 +21,7 @@ impl Event for ProvideBuffers {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        let mut buf: ManuallyDrop<Box<[u8]>> = ManuallyDrop::new(ManuallyDrop::take(this).bufs);
-        let cap = buf.len();
-        Cancellation::buffer(buf.as_mut_ptr(), cap)
+        Cancellation::buffer(ManuallyDrop::take(this).bufs)
     }
 }
 

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -20,8 +20,6 @@ impl Event for Read {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        let mut buf: ManuallyDrop<Box<[u8]>> = ManuallyDrop::new(ManuallyDrop::take(this).buf);
-        let cap = buf.len();
-        Cancellation::buffer(buf.as_mut_ptr(), cap)
+        Cancellation::buffer(ManuallyDrop::take(this).buf)
     }
 }

--- a/src/event/recv.rs
+++ b/src/event/recv.rs
@@ -21,8 +21,6 @@ impl Event for Recv {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        let mut buf: ManuallyDrop<Box<[u8]>> = ManuallyDrop::new(ManuallyDrop::take(this).buf);
-        let cap = buf.len();
-        Cancellation::buffer(buf.as_mut_ptr(), cap)
+        Cancellation::buffer(ManuallyDrop::take(this).buf)
     }
 }

--- a/src/event/send.rs
+++ b/src/event/send.rs
@@ -21,8 +21,6 @@ impl Event for Send {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        let mut buf: ManuallyDrop<Box<[u8]>> = ManuallyDrop::new(ManuallyDrop::take(this).buf);
-        let cap = buf.len();
-        Cancellation::buffer(buf.as_mut_ptr(), cap)
+        Cancellation::buffer(ManuallyDrop::take(this).buf)
     }
 }

--- a/src/event/timeout.rs
+++ b/src/event/timeout.rs
@@ -59,10 +59,7 @@ impl Event for Timeout {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(ts: *mut (), _: usize) {
-            drop(Box::from_raw(ts as *mut uring_sys::__kernel_timespec))
-        }
-        Cancellation::new(&mut *this.ts as *mut uring_sys::__kernel_timespec as *mut (), 0, callback)
+        Cancellation::object(ManuallyDrop::take(this).ts)
     }
 }
 

--- a/src/event/write.rs
+++ b/src/event/write.rs
@@ -20,8 +20,6 @@ impl Event for Write {
     }
 
     unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        let mut buf: ManuallyDrop<Box<[u8]>> = ManuallyDrop::new(ManuallyDrop::take(this).buf);
-        let cap = buf.len();
-        Cancellation::buffer(buf.as_mut_ptr(), cap)
+        Cancellation::buffer(ManuallyDrop::take(this).buf)
     }
 }

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -72,15 +72,7 @@ impl<D: Drive> TcpListener<D> {
 
     fn cancel(&mut self) {
         let cancellation = match self.active {
-            Op::Accept => {
-                unsafe fn callback(addr: *mut (), _: usize) {
-                    drop(Box::from_raw(addr as *mut iou::sqe::SockAddrStorage))
-                }
-                unsafe {
-                    let addr: &mut iou::sqe::SockAddrStorage = &mut **self.addr.as_mut().unwrap();
-                    Cancellation::new(addr as *mut iou::sqe::SockAddrStorage as *mut (), 0, callback)
-                }
-            }
+            Op::Accept  => self.addr.take().map_or_else(Cancellation::null, Cancellation::object),
             Op::Close   => Cancellation::null(),
             Op::Closed  => return,
             Op::Nothing => return,

--- a/tests/basic-readv.rs
+++ b/tests/basic-readv.rs
@@ -10,12 +10,12 @@ const ASSERT: &[u8] = b"But this formidable power of death -";
 #[test]
 fn readv_file() {
     let file = File::open("props.txt").unwrap();
-    let vec1 = Box::new([0; 4]);
-    let vec2 = Box::new([0; 5]);
-    let vec3 = Box::new([0; 10]);
+    let vec1: Box<[u8]> = Box::new([0; 4]);
+    let vec2: Box<[u8]> = Box::new([0; 5]);
+    let vec3: Box<[u8]> = Box::new([0; 10]);
     let readv = ReadVectored {
         fd: file.as_raw_fd(),
-        bufs: vec![vec1, vec2, vec3],
+        bufs: vec![vec1, vec2, vec3].into_boxed_slice(),
         offset: 0,
     };
     let (readv, result) = futures::executor::block_on(Submission::new(readv, demo::driver()));

--- a/tests/basic-writev.rs
+++ b/tests/basic-writev.rs
@@ -15,7 +15,7 @@ fn writev_file() {
     let vec3 = &ASSERT[9..];
     let writev = WriteVectored {
         fd: file.as_raw_fd(),
-        bufs: vec![vec1.into(), vec2.into(), vec3.into()],
+        bufs: vec![vec1.into(), vec2.into(), vec3.into()].into(),
         offset: 0,
     };
     let (_, result) = futures::executor::block_on(Submission::new(writev, demo::driver()));


### PR DESCRIPTION
Cancellation gains 3 safe constructors: one for boxed objects, one for boxed trait objects, and one for boxed slices. Almost the entire rest of ringbahn can go through one of these safe APIs, eliminating a major source of pervasive unsoundness.

Also gets rid of the now unnecessary UringData trait added in #52. As a result the buffer code is basically entirely safe now.