### PR TITLE
Add Cancel trait.

### DIFF
--- a/src/buf/data.rs
+++ b/src/buf/data.rs
@@ -27,7 +27,7 @@ impl Data {
     }
 
     pub fn cancellation(&mut self) -> Cancellation {
-        self.inner.take().map_or_else(Cancellation::null, Inner::cancellation)
+        Cancellation::from(self.inner.take())
     }
 }
 
@@ -57,11 +57,13 @@ impl Inner {
             Inner::Object(_)        => None,
         }
     }
+}
 
-    fn cancellation(self) -> Cancellation {
-        match self {
-            Inner::Buffer(bytes)    => Cancellation::buffer(bytes),
-            Inner::Object(object)   => Cancellation::dyn_object(object),
+impl From<Inner> for Cancellation {
+    fn from(inner: Inner) -> Cancellation {
+        match inner {
+            Inner::Buffer(bytes)    => Cancellation::from(bytes),
+            Inner::Object(object)   => Cancellation::from(object),
         }
     }
 }

--- a/src/event/accept.rs
+++ b/src/event/accept.rs
@@ -21,7 +21,7 @@ impl<FD: UringFd + Copy> Event for Accept<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        this.addr.take().map_or_else(Cancellation::null, Cancellation::object)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).addr)
     }
 }

--- a/src/event/close.rs
+++ b/src/event/close.rs
@@ -1,9 +1,8 @@
-use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
 use iou::registrar::UringFd;
 
-use super::{Event, SQE, SQEs, Cancellation};
+use super::{Event, SQE, SQEs};
 
 pub struct Close<FD = RawFd> {
     pub fd: FD,
@@ -16,9 +15,5 @@ impl<FD: UringFd + Copy> Event for Close<FD> {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_close(self.fd);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/connect.rs
+++ b/src/event/connect.rs
@@ -1,5 +1,5 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::sqe::SockAddr;
 use iou::registrar::UringFd;
@@ -20,7 +20,7 @@ impl<FD: UringFd + Copy> Event for Connect<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::object(ManuallyDrop::take(this).addr)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).addr)
     }
 }

--- a/src/event/epoll_ctl.rs
+++ b/src/event/epoll_ctl.rs
@@ -21,7 +21,7 @@ impl Event for EpollCtl {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        this.event.take().map_or_else(Cancellation::null, Cancellation::object)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).event)
     }
 }

--- a/src/event/fadvise.rs
+++ b/src/event/fadvise.rs
@@ -1,10 +1,9 @@
-use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
 use iou::sqe::PosixFadviseAdvice;
 use iou::registrar::UringFd;
 
-use super::{Event, SQE, SQEs, Cancellation};
+use super::{Event, SQE, SQEs};
 
 pub struct Fadvise<FD = RawFd> {
     pub fd: FD,
@@ -20,9 +19,5 @@ impl<FD: UringFd + Copy> Event for Fadvise<FD> {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_fadvise(self.fd, self.offset, self.size, self.flags);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/fallocate.rs
+++ b/src/event/fallocate.rs
@@ -1,10 +1,9 @@
-use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
 use iou::registrar::UringFd;
 use iou::sqe::FallocateFlags;
 
-use super::{Event, SQE, SQEs, Cancellation};
+use super::{Event, SQE, SQEs};
 
 pub struct Fallocate<FD = RawFd> {
     pub fd: FD,
@@ -20,9 +19,5 @@ impl<FD: UringFd + Copy> Event for Fallocate<FD> {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_fallocate(self.fd, self.offset, self.size, self.flags);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/files_update.rs
+++ b/src/event/files_update.rs
@@ -1,5 +1,5 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use super::{Event, SQE, SQEs, Cancellation};
 
@@ -17,7 +17,7 @@ impl Event for FilesUpdate {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).files)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).files)
     }
 }

--- a/src/event/fsync.rs
+++ b/src/event/fsync.rs
@@ -1,10 +1,9 @@
-use std::mem::ManuallyDrop;
 use std::os::unix::io::RawFd;
 
 use iou::registrar::UringFd;
 use iou::sqe::FsyncFlags;
 
-use super::{Event, SQE, SQEs, Cancellation};
+use super::{Event, SQE, SQEs};
 
 pub struct Fsync<FD = RawFd> {
     pub fd: FD,
@@ -18,9 +17,5 @@ impl<FD: UringFd + Copy> Event for Fsync<FD> {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_fsync(self.fd, self.flags);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -22,8 +22,9 @@ mod writev;
 
 use std::mem::ManuallyDrop;
 
-use crate::cancellation::Cancellation;
 use iou::{SQE, SQEs};
+
+use crate::cancellation::Cancellation;
 
 pub use accept::Accept;
 pub use close::Close;
@@ -82,14 +83,7 @@ pub trait Event {
     /// If this event is cancelled, this callback will be stored with the completion to be dropped
     /// when the IO event completes. This way, any managed resources passed to the kernel (like
     /// buffers) can be cleaned up once the kernel no longer needs them.
-    ///
-    /// ## Safety
-    ///
-    /// When this method is called, the event will never accessed again in any way. No methods will
-    /// ever be called, including its destructor. The cancellation that is constructed will then
-    /// not be dropped until after the event has been completed by the kernel.
-    ///
-    /// The cancellation can take ownership from the event of any resources owned by the kernel,
-    /// and then clean up those resources when the kernel completes the event.
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation;
+    fn cancel(_: ManuallyDrop<Self>) -> Cancellation where Self: Sized {
+        Cancellation::from(())
+    }
 }

--- a/src/event/openat.rs
+++ b/src/event/openat.rs
@@ -31,7 +31,7 @@ impl Event for OpenAt {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::cstring(ManuallyDrop::take(this).path)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).path)
     }
 }

--- a/src/event/provide_buffers.rs
+++ b/src/event/provide_buffers.rs
@@ -1,5 +1,4 @@
 use std::mem::ManuallyDrop;
-
 use iou::sqe::BufferGroupId;
 
 use super::{Event, SQE, SQEs, Cancellation};
@@ -20,8 +19,8 @@ impl Event for ProvideBuffers {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).bufs)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).bufs)
     }
 }
 
@@ -37,9 +36,5 @@ impl Event for RemoveBuffers {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_remove_buffers(self.count, self.group);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -1,12 +1,12 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::registrar::{UringFd, RegisteredBuf};
 
 use super::{Event, SQE, SQEs, Cancellation};
 
 /// A basic read event.
-pub struct Read<FD = RawFd>{
+pub struct Read<FD = RawFd> {
     pub fd: FD,
     pub buf: Box<[u8]>,
     pub offset: u64,
@@ -21,8 +21,8 @@ impl<FD: UringFd + Copy> Event for Read<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }
 
@@ -41,7 +41,7 @@ impl<FD: UringFd + Copy> Event for ReadFixed<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf.into_inner())
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }

--- a/src/event/readv.rs
+++ b/src/event/readv.rs
@@ -1,6 +1,6 @@
 use std::io::IoSliceMut; 
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::registrar::UringFd;
 
@@ -42,7 +42,7 @@ impl<FD: UringFd + Copy> Event for ReadVectored<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).bufs)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).bufs)
     }
 }

--- a/src/event/recv.rs
+++ b/src/event/recv.rs
@@ -1,5 +1,5 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::sqe::MsgFlags;
 use iou::registrar::UringFd;
@@ -21,7 +21,7 @@ impl<FD: UringFd + Copy> Event for Recv<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }

--- a/src/event/send.rs
+++ b/src/event/send.rs
@@ -1,5 +1,5 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::sqe::MsgFlags;
 use iou::registrar::UringFd;
@@ -21,7 +21,7 @@ impl<FD: UringFd + Copy> Event for Send<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }

--- a/src/event/splice.rs
+++ b/src/event/splice.rs
@@ -1,9 +1,8 @@
 use std::os::unix::io::RawFd;
-use std::mem::ManuallyDrop;
 
 use iou::sqe::SpliceFlags;
 
-use super::{Event, SQE, SQEs, Cancellation};
+use super::{Event, SQE, SQEs};
 
 pub struct Splice {
     pub fd_in: RawFd,
@@ -21,9 +20,5 @@ impl Event for Splice {
         let mut sqe = sqs.single().unwrap();
         sqe.prep_splice(self.fd_in, self.off_in, self.fd_out, self.off_out, self.bytes, self.flags);
         sqe
-    }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
     }
 }

--- a/src/event/statx.rs
+++ b/src/event/statx.rs
@@ -46,15 +46,8 @@ impl<FD: UringFd + Copy> Event for Statx<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        unsafe fn callback(addr: *mut (), path: usize) {
-            drop(Box::from_raw(addr as *mut libc::statx));
-            drop(CString::from_raw(path as *mut libc::c_char))
-        }
-        Cancellation::new(
-            &mut *this.statx as *mut libc::statx as *mut (),
-            this.path.as_ptr() as usize,
-            callback,
-        )
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        let this = ManuallyDrop::into_inner(this);
+        Cancellation::from((this.statx, this.path))
     }
 }

--- a/src/event/timeout.rs
+++ b/src/event/timeout.rs
@@ -28,10 +28,6 @@ impl Event for &'static StaticTimeout {
         sqe.prep_timeout(&self.ts, self.events, self.flags);
         sqe
     }
-
-    unsafe fn cancel(_: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::null()
-    }
 }
 
 pub struct Timeout {
@@ -58,8 +54,8 @@ impl Event for Timeout {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::object(ManuallyDrop::take(this).ts)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).ts)
     }
 }
 

--- a/src/event/write.rs
+++ b/src/event/write.rs
@@ -1,5 +1,5 @@
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::registrar::{UringFd, RegisteredBuf};
 
@@ -21,8 +21,8 @@ impl<FD: UringFd + Copy> Event for Write<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }
 
@@ -41,7 +41,7 @@ impl<FD: UringFd + Copy> Event for WriteFixed<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).buf.into_inner())
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).buf)
     }
 }

--- a/src/event/writev.rs
+++ b/src/event/writev.rs
@@ -1,6 +1,6 @@
 use std::io::IoSlice; 
-use std::os::unix::io::RawFd;
 use std::mem::ManuallyDrop;
+use std::os::unix::io::RawFd;
 
 use iou::registrar::UringFd;
 
@@ -28,7 +28,7 @@ impl<FD: UringFd + Copy> Event for WriteVectored<FD> {
         sqe
     }
 
-    unsafe fn cancel(this: &mut ManuallyDrop<Self>) -> Cancellation {
-        Cancellation::buffer(ManuallyDrop::take(this).bufs)
+    fn cancel(this: ManuallyDrop<Self>) -> Cancellation {
+        Cancellation::from(ManuallyDrop::into_inner(this).bufs)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod completion;
 mod ring;
 mod submission;
 
-pub use cancellation::Cancellation;
+pub use cancellation::{Cancel, Cancellation};
 pub use ring::Ring;
 pub use submission::Submission;
 

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -72,8 +72,8 @@ impl<D: Drive> TcpListener<D> {
 
     fn cancel(&mut self) {
         let cancellation = match self.active {
-            Op::Accept  => self.addr.take().map_or_else(Cancellation::null, Cancellation::object),
-            Op::Close   => Cancellation::null(),
+            Op::Accept  => Cancellation::from(self.addr.take()),
+            Op::Close   => Cancellation::from(()),
             Op::Closed  => return,
             Op::Nothing => return,
         };

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -11,7 +11,7 @@ use crate::{Event, Drive, Ring};
 /// A [`Future`] representing an event submitted to io-uring
 pub struct Submission<E: Event, D: Drive> {
     ring: Ring<D>,
-    event: Option<ManuallyDrop<E>>,
+    event: Option<E>,
 }
 
 impl<E: Event, D: Drive> Submission<E, D> {
@@ -19,7 +19,7 @@ impl<E: Event, D: Drive> Submission<E, D> {
     pub fn new(event: E, driver: D) -> Submission<E, D> {
         Submission {
             ring: Ring::new(driver),
-            event: Some(ManuallyDrop::new(event)),
+            event: Some(event),
         }
     }
 
@@ -30,14 +30,13 @@ impl<E: Event, D: Drive> Submission<E, D> {
 
     pub fn replace_event(self: Pin<&mut Self>, event: E) {
         let (ring, event_slot) = self.split();
-        if let Some(event) = &mut *event_slot {
-            let cancellation = unsafe { Event::cancel(event) };
-            ring.cancel_pinned(cancellation);
+        if let Some(event) = event_slot.take() {
+            ring.cancel_pinned(E::cancel(ManuallyDrop::new(event)))
         }
-        *event_slot = Some(ManuallyDrop::new(event));
+        *event_slot = Some(event);
     }
 
-    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Option<ManuallyDrop<E>>) {
+    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Option<E>) {
         unsafe {
             let this = Pin::get_unchecked_mut(self);
             (Pin::new_unchecked(&mut this.ring), &mut this.event)
@@ -61,16 +60,15 @@ impl<E, D> Future for Submission<E, D> where
             panic!("polled Submission after completion")
         };
 
-        Poll::Ready((ManuallyDrop::into_inner(event.take().unwrap()), result))
+        Poll::Ready((event.take().unwrap(), result))
     }
 }
 
 
 impl<E: Event, D: Drive> Drop for Submission<E, D> {
     fn drop(&mut self) {
-        if let Some(event) = &mut self.event {
-            let cancellation = unsafe { Event::cancel(event) };
-            self.ring.cancel(cancellation);
+        if let Some(event) = self.event.take() {
+            self.ring.cancel(E::cancel(ManuallyDrop::new(event)))
         }
     }
 }

--- a/src/unix/listener.rs
+++ b/src/unix/listener.rs
@@ -69,7 +69,7 @@ impl<D: Drive> UnixListener<D> {
     fn cancel(&mut self) {
         if !matches!(self.active, Op::Nothing | Op::Closed) {
             self.active = Op::Nothing;
-            self.ring.cancel(Cancellation::null());
+            self.ring.cancel(Cancellation::from(()));
         }
     }
 


### PR DESCRIPTION
This provides a cleaner way to construct a Cancellation: it can now be
constructed from any type that implements Cancel, which includes things
like Boxes, CStrings, buffers, etc. All constructions of Cancellation
now pass through `Cancellation::from`, instead of unique constructors
for different types.

The Cancel trait provides a way to decompose an object into two words,
and then a way to drop that object from those two words. A Cancellation
is essentially `Box<dyn Drop>`, except it stores an extra word for
metadata for slices and trait objects.

Event::cancel has been changed to take ownership of the receiver, be
safe, and have a default implementation (which just leaks the receiver).
By default, therefore, the data owned by an event is leaked. An
implementation can instead construct a cancellation to deallocate the
data it owns.