### PR TITLE
use as_deref_mut for events holding Options

### DIFF
--- a/src/event/accept.rs
+++ b/src/event/accept.rs
@@ -17,7 +17,7 @@ impl<FD: UringFd + Copy> Event for Accept<FD> {
 
     unsafe fn prepare<'sq>(&mut self, sqs: &mut SQEs<'sq>) -> SQE<'sq> {
         let mut sqe = sqs.single().unwrap();
-        sqe.prep_accept(self.fd, self.addr.as_mut().map(|addr| &mut **addr), self.flags);
+        sqe.prep_accept(self.fd, self.addr.as_deref_mut(), self.flags);
         sqe
     }
 

--- a/src/event/epoll_ctl.rs
+++ b/src/event/epoll_ctl.rs
@@ -17,7 +17,7 @@ impl Event for EpollCtl {
 
     unsafe fn prepare<'sq>(&mut self, sqs: &mut SQEs<'sq>) -> SQE<'sq> {
         let mut sqe = sqs.single().unwrap();
-        sqe.prep_epoll_ctl(self.epoll_fd, self.op, self.fd, self.event.as_mut().map(|e| &mut **e));
+        sqe.prep_epoll_ctl(self.epoll_fd, self.op, self.fd, self.event.as_deref_mut());
         sqe
     }
 


### PR DESCRIPTION
(Flagged by clippy) use `as_deref_mut` method calls for the two events that contain an `Option`. 