### PR TITLE
Use the NODROP feature in demo driver.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-access-queue = "1.1.0"
 futures-io = "0.3.5"
 futures-core = "0.3.5"
 parking_lot = "0.10.2"
@@ -18,6 +17,7 @@ uring-sys = "0.7.4"
 nix = "0.18.0"
 iou = "0.3.3"
 either = "1.6.1"
+event-listener = "2.5.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -24,7 +24,7 @@ use crate::Submission;
 type FileBuf = Either<Buffer, Box<libc::statx>>;
 
 /// A file handle that runs on io-uring
-pub struct File<D: Drive = DemoDriver<'static>> {
+pub struct File<D: Drive = DemoDriver> {
     ring: Ring<D>,
     fd: RawFd,
     active: Op,
@@ -318,7 +318,7 @@ impl<D: Drive> Drop for File<D> {
 }
 
 /// A future representing an opening file.
-pub struct Open<D: Drive = DemoDriver<'static>>(Submission<OpenAt, D>);
+pub struct Open<D: Drive = DemoDriver>(Submission<OpenAt, D>);
 
 impl<D: Drive> Open<D> {
     fn inner(self: Pin<&mut Self>) -> Pin<&mut Submission<OpenAt, D>> {
@@ -339,7 +339,7 @@ impl<D: Drive + Clone> Future for Open<D> {
 }
 
 /// A future representing a file being created.
-pub struct Create<D: Drive = DemoDriver<'static>>(Submission<OpenAt, D>);
+pub struct Create<D: Drive = DemoDriver>(Submission<OpenAt, D>);
 
 impl<D: Drive> Create<D> {
     fn inner(self: Pin<&mut Self>) -> Pin<&mut Submission<OpenAt, D>> {

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -14,7 +14,7 @@ use crate::ring::{Cancellation, Ring};
 
 use super::TcpStream;
 
-pub struct TcpListener<D: Drive = DemoDriver<'static>> {
+pub struct TcpListener<D: Drive = DemoDriver> {
     ring: Ring<D>,
     fd: RawFd,
     active: Op,

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -18,7 +18,7 @@ use crate::Submission;
 
 use super::socket;
 
-pub struct TcpStream<D: Drive = DemoDriver<'static>> {
+pub struct TcpStream<D: Drive = DemoDriver> {
     ring: Ring<D>,
     buf: Buffer,
     active: Op,
@@ -98,7 +98,7 @@ impl<D: Drive> TcpStream<D> {
     }
 }
 
-pub struct Connect<D: Drive = DemoDriver<'static>>(
+pub struct Connect<D: Drive = DemoDriver>(
     Result<Submission<event::Connect, D>, Option<io::Error>>
 );
 

--- a/src/unix/listener.rs
+++ b/src/unix/listener.rs
@@ -13,7 +13,7 @@ use crate::ring::{Ring, Cancellation};
 
 use super::UnixStream;
 
-pub struct UnixListener<D: Drive = DemoDriver<'static>> {
+pub struct UnixListener<D: Drive = DemoDriver> {
     ring: Ring<D>,
     fd: RawFd,
     active: Op,

--- a/src/unix/stream.rs
+++ b/src/unix/stream.rs
@@ -19,7 +19,7 @@ use super::{socket, socketpair};
 
 use crate::net::TcpStream;
 
-pub struct UnixStream<D: Drive = DemoDriver<'static>> {
+pub struct UnixStream<D: Drive = DemoDriver> {
     inner: TcpStream<D>,
 }
 
@@ -64,7 +64,7 @@ impl<D: Drive> UnixStream<D> {
     }
 }
 
-pub struct Connect<D: Drive = DemoDriver<'static>>(
+pub struct Connect<D: Drive = DemoDriver>(
     Result<Submission<event::Connect, D>, Option<io::Error>>
 );
 


### PR DESCRIPTION
Rather than tracking for ourselves how many events can be in the air at
once, we use the NODROP feature to have io-uring report EBUSY if we
submit more events than it can complete. We use event-listener to wake
up tasks that are blocking on submission.