### PR TITLE
add Stdout handle

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -116,7 +116,7 @@ pub struct Stdout<D: Drive> {
     buf: Buffer,
 }
 
-/// Constructs a new handle to the standard output of the current process using the demo driver.
+/// Constructs a new `stdout` handle run on the demo driver.
 /// ```no_run
 /// use ringbahn::io;
 ///
@@ -129,17 +129,18 @@ pub struct Stdout<D: Drive> {
 /// ```
 // TODO synchronization note?
 pub fn stdout() -> Stdout<DemoDriver> {
-    Stdout::run_on_driver(DemoDriver::default())
+    stdout_on_driver(DemoDriver::default())
+}
+
+/// Constructs a new `stdout` handle run on the provided driver.
+pub fn stdout_on_driver<D: Drive>(driver: D) -> Stdout<D> {
+    Stdout {
+        ring: Ring::new(driver),
+        buf: Buffer::default(),
+    }
 }
 
 impl<D: Drive> Stdout<D> {
-    pub fn run_on_driver(driver: D) -> Stdout<D> {
-        Stdout {
-            ring: Ring::new(driver),
-            buf: Buffer::default(),
-        }
-    }
-
     #[inline(always)]
     fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer) {
         unsafe {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,13 +1,16 @@
 use std::borrow::Cow;
 use std::future::Future;
 use std::io;
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::task::{Poll, Context};
 
 use futures_core::ready;
+use futures_io::AsyncWrite;
 
+use crate::buf::Buffer;
 use crate::{Drive, ring::Ring};
+use crate::drive::demo::DemoDriver;
 
 #[macro_export]
 macro_rules! print {
@@ -104,5 +107,80 @@ impl<D: Drive> Future for Print<D> {
         } else {
             return Poll::Ready(Ok(()));
         }
+    }
+}
+
+/// A handle to the standard output of the current process.
+pub struct Stdout<D: Drive> {
+    ring: Ring<D>,
+    buf: Buffer,
+}
+
+/// Constructs a new handle to the standard output of the current process using the demo driver.
+/// ```no_run
+/// use ringbahn::io;
+///
+/// # use futures::AsyncWriteExt;
+/// # fn main() -> std::io::Result<()> { futures::executor::block_on(async {
+/// io::stdout().write(b"hello, world").await?;
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+// TODO synchronization note?
+pub fn stdout() -> Stdout<DemoDriver> {
+    Stdout::run_on_driver(DemoDriver::default())
+}
+
+impl<D: Drive> Stdout<D> {
+    pub fn run_on_driver(driver: D) -> Stdout<D> {
+        Stdout {
+            ring: Ring::new(driver),
+            buf: Buffer::default(),
+        }
+    }
+
+    #[inline(always)]
+    fn split(self: Pin<&mut Self>) -> (Pin<&mut Ring<D>>, &mut Buffer) {
+        unsafe {
+            let this = Pin::get_unchecked_mut(self);
+            (Pin::new_unchecked(&mut this.ring), &mut this.buf)
+        }
+    }
+}
+
+impl<D: Drive> AsyncWrite for Stdout<D> {
+    fn poll_write(self: Pin<&mut Self>, ctx: &mut Context<'_>, slice: &[u8])
+        -> Poll<io::Result<usize>>
+    {
+        let fd = self.as_raw_fd();
+        let (ring, buf, ..) = self.split();
+        let data = ready!(buf.fill_buf(|mut buf| {
+            Poll::Ready(Ok(io::Write::write(&mut buf, slice)? as u32))
+        }))?;
+        let n = ready!(ring.poll(ctx, 1, |sqs| {
+            let mut sqe = sqs.single().unwrap();
+            unsafe {
+                sqe.prep_write(fd, data, 0);
+            }
+            sqe
+        }))?;
+        buf.clear();
+        Poll::Ready(Ok(n as usize))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        ready!(self.poll_write(ctx, &[]))?;
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_flush(ctx)
+    }
+}
+
+impl<D: Drive> AsRawFd for Stdout<D> {
+    fn as_raw_fd(&self) -> RawFd {
+        libc::STDOUT_FILENO
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub mod drive;
 pub mod event;
 pub mod ring;
 
-#[doc(hidden)]
 pub mod io;
 
 mod buf;

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -1,0 +1,16 @@
+use futures::AsyncWriteExt;
+
+use ringbahn::{drive::demo, io::Stdout};
+
+const ASSERT: &[u8] = b"Hello, world!\n";
+
+#[test]
+fn write_stdout() {
+    futures::executor::block_on(async {
+        let n = ringbahn::io::stdout().write(ASSERT).await.unwrap();
+        assert_eq!(n, ASSERT.len());
+        let mut stdout = Stdout::run_on_driver(demo::driver());
+        let n = stdout.write(ASSERT).await.unwrap();
+        assert_eq!(n, ASSERT.len());
+    });
+}

--- a/tests/stdio.rs
+++ b/tests/stdio.rs
@@ -1,6 +1,6 @@
 use futures::AsyncWriteExt;
 
-use ringbahn::{drive::demo, io::Stdout};
+use ringbahn::{drive::demo};
 
 const ASSERT: &[u8] = b"Hello, world!\n";
 
@@ -9,7 +9,7 @@ fn write_stdout() {
     futures::executor::block_on(async {
         let n = ringbahn::io::stdout().write(ASSERT).await.unwrap();
         assert_eq!(n, ASSERT.len());
-        let mut stdout = Stdout::run_on_driver(demo::driver());
+        let mut stdout = ringbahn::io::stdout_on_driver(demo::driver());
         let n = stdout.write(ASSERT).await.unwrap();
         assert_eq!(n, ASSERT.len());
     });


### PR DESCRIPTION
Add an io-uring based `Stdout` handle. The `AsyncWrite` implementation is basically lifted wholesale from the other IO events (e.g. `TcpStream`). The eventual idea is to replace `io::Print` with calls to `stdout().write_all` and `stderr().write_all`. Maybe an alternative implementation could be wrapping `Print` in `Stdout` and `Stderr` newtypes because of how similar they are.